### PR TITLE
aws - Q11 answer

### DIFF
--- a/aws/aws-quiz.md
+++ b/aws/aws-quiz.md
@@ -64,7 +64,7 @@
 
 #### Q11. When using an ECS cluster with EC2 instances, what maintenance tasks should you perform on the EC2s?
 - [ ] The instances created by ECS do not have patches that need to be applied; however, you should make sure your containers contain any important security updates.
-- [ ] Refresh the cluster with instances built from the latest ECS AMI.
+- [x] Refresh the cluster with instances built from the latest ECS AMI.
 - [ ] ECS clusters do not use EC2 instances.
 - [ ] You should not directly manipulate the EC2 instances created by ECS. AWS will automatically update these instances.
 


### PR DESCRIPTION
ecs can use ec2 via scaling group, so the updates are in the latest image.