### PR TITLE
aws Q55

### DIFF
--- a/aws/aws-quiz.md
+++ b/aws/aws-quiz.md
@@ -392,7 +392,7 @@ aws ec2 associate-address --instance-id i-8b953 --allocation-id eipalloc-02d021a
 ![image](https://user-images.githubusercontent.com/8637045/112515574-c077e780-8d6c-11eb-96a6-11f27a0547cf.png)
 
 - [ ] The outbound rules block UDP port 53, so the server will not be able to resolve any DNS lookups.
-- [ ] The outbound rules do not allow for HTTP traffic to leave the instance, so inbound HTTP requests will fail because the clients will never get HTTP responses.
+- [x] The outbound rules do not allow for HTTP traffic to leave the instance, so inbound HTTP requests will fail because the clients will never get HTTP responses.
 - [ ] The incoming SSH port should not be open to the public.  Limit SSH to a single IP address or IP range of controlled addressed, or use a VPN to access the VPC for this server.
 - [ ] The all incoming TCP ports are exposed, which overrides the HTTP and SSH rules and exposes all TCP ports to the public internet.
 


### PR DESCRIPTION
The outbound rules for the http 80 must be allowed also.